### PR TITLE
[folly] fix use after free in AsyncSocketIntegrationTest.PingPongNotifyMmsg

### DIFF
--- a/folly/io/async/test/AsyncUDPSocketTest.cpp
+++ b/folly/io/async/test/AsyncUDPSocketTest.cpp
@@ -175,8 +175,9 @@ class UDPServer {
 
   std::unique_ptr<AsyncUDPServerSocket> socket_;
   std::vector<std::thread> threads_;
-  std::vector<folly::EventBase> evbs_;
   std::vector<UDPAcceptor> acceptors_;
+  // destroy evbs_ before acceptors_ so that onListenStopped not called on a freed UDPAcceptor
+  std::vector<folly::EventBase> evbs_;
   bool changePortForWrites_{true};
 };
 


### PR DESCRIPTION
Summary:

Test fix to reorder members so that we destroy evbs_ before acceptors_ so that onListenStopped not called on a freed UDPAcceptor.

Fixes intermitted use after free segfault in test io_async_async_udp_socket_test.AsyncSocketIntegrationTest.PingPongNotifyMmsg  [ github CI example](https://github.com/facebook/folly/actions/runs/19988915131/job/57326786353#step:100:7347).

Test Plan:

Reproduced locally via:
```
while ./build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. --retry 0 folly; do echo ok; done
```

Before, fails after a few minutes
```
  io_async_async_udp_socket_test.AsyncSocketIntegrationTest.PingPongNotifyMmsg .............................................***Exception: SegFault  0.31 sec
  Note: Google Test filter = AsyncSocketIntegrationTest.PingPongNotifyMmsg
  [==========] Running 1 test from 1 test suite.
  [----------] Global test environment set-up.
  [----------] 1 test from AsyncSocketIntegrationTest
  [ RUN      ] AsyncSocketIntegrationTest.PingPongNotifyMmsg
  I20251206 17:03:03.273430 472420 AsyncUDPSocketTest.cpp:465] Server listening=127.0.0.1:39115
  *** Aborted at 1765040583 (Unix time, try 'date -d @1765040583') ***
  *** Signal 11 (SIGSEGV) (0x7f9758009) received by PID 472420 (pthread TID 0x7f975cf0cfc0) (linux TID 472420) (code: address not mapped to object), stack trace: ***
      @ 000000000014ee22 _ZN5folly10symbolizer12_GLOBAL__N_113signalHandlerEiP9siginfo_tPv
                         /home/alex/local/folly/folly/debugging/symbolizer/SignalHandler.cpp:526
      @ 000000000004251f (unknown)
      @ 000000000005e531 _ZN5folly6detail8function5call_IZNS_20AsyncUDPServerSocket12onReadClosedEvEUlvE_Lb1ELb0EvJEEET2_DpT3_RNS1_4DataE
                         /home/alex/local/folly/folly/io/async/AsyncUDPServerSocket.h:342
                         -> /home/alex/local/folly/folly/io/async/test/AsyncUDPSocketTest.cpp
      @ 00000000000d61b8 _ZN5folly23AtomicNotificationQueueINS_8FunctionIFvvEEEE5driveIRNS_9EventBase10FuncRunnerEEEbOT_
                         /home/alex/local/folly/folly/Function.h:370
                         -> /home/alex/local/folly/folly/io/async/EventBase.cpp
      @ 00000000000d2762 _ZN5folly9EventBaseD1Ev
                         /home/alex/local/folly/folly/io/async/EventBaseAtomicNotificationQueue-inl.h:275
                         -> /home/alex/local/folly/folly/io/async/EventBase.cpp
      @ 00000000000a3a2f _ZN26AsyncSocketIntegrationTestD2Ev
                         /usr/include/c++/11/bits/stl_construct.h:88
                         -> /home/alex/local/folly/folly/io/async/test/AsyncUDPSocketTest.cpp
      @ 00000000000a3f16 _ZN50AsyncSocketIntegrationTest_PingPongNotifyMmsg_TestD0Ev
                         /home/alex/local/folly/folly/io/async/test/AsyncUDPSocketTest.cpp:618
      @ 000000000022bc2e _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest.cc:2599
                         -> /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest-all.cc
      @ 000000000021c8ac _ZN7testing8TestInfo3RunEv
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest.cc:2859
                         -> /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest-all.cc
      @ 000000000021d022 _ZN7testing9TestSuite3RunEv.part.0
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest.cc:3012
                         -> /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest-all.cc
      @ 000000000022222b _ZN7testing8internal12UnitTestImpl11RunAllTestsEv
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest.cc:2986
                         -> /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest-all.cc
      @ 000000000022c1f6 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest.cc:2599
                         -> /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest-all.cc
      @ 000000000021c9ff _ZN7testing8UnitTest3RunEv
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest.cc:5444
                         -> /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/extracted/googletest-release-1.12.1.tar.gz/googletest-release-1.12.1/googletest/src/
  gtest-all.cc
      @ 000000000004bf4b main
                         /home/alex/local/tmp/ubuntu-22.04/fbcode_builder_getdeps-ZhomeZalexZlocalZfollyZbuildZfbcode_builder/installed/googletest-Hv1WWy2VPcuaFD_4gPiXoC0RaDUVDIVPy0lsa_KINtA/include/gtest/
  gtest.h:2293
                         -> /home/alex/local/folly/folly/test/common/TestMain.cpp
      @ 0000000000029d8f (unknown)
      @ 0000000000029e3f __libc_start_main
      @ 000000000004d2a4 _start
```

After,  works for an hour
```
```